### PR TITLE
feat(sitemap): add scully sitemap plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2252,6 +2252,12 @@
         "purgecss": "^2.1.2"
       }
     },
+    "@gammastream/scully-plugin-sitemap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@gammastream/scully-plugin-sitemap/-/scully-plugin-sitemap-1.0.0.tgz",
+      "integrity": "sha512-MGOs34hkCmbW3TBFB7zj/cqrzj7i37fPhQfQfJ2qzHCoiCaiPXoJIrmYNtwnE46AjYPQM5pQ/eMiiYctWr8gGw==",
+      "dev": true
+    },
     "@ionic/angular": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/@ionic/angular/-/angular-5.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "@angular/cli": "9.1.7",
     "@angular/compiler-cli": "9.1.9",
     "@angular/language-service": "9.1.9",
-    "@gammastream/scully-plugin-sitemap": "~1.0.0",
+    "@gammastream/scully-plugin-sitemap": "1.0.0",
     "@ionic/angular-toolkit": "2.2.0",
     "@notiz/scully-plugin-fouc": "0.2.0",
     "@notiz/scully-plugin-lazy-images": "0.2.7",

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "@angular/cli": "9.1.7",
     "@angular/compiler-cli": "9.1.9",
     "@angular/language-service": "9.1.9",
+    "@gammastream/scully-plugin-sitemap": "~1.0.0",
     "@ionic/angular-toolkit": "2.2.0",
     "@notiz/scully-plugin-fouc": "0.2.0",
     "@notiz/scully-plugin-lazy-images": "0.2.7",

--- a/scully.notiz.config.ts
+++ b/scully.notiz.config.ts
@@ -1,9 +1,11 @@
+import { ScullyConfig, setPluginConfig } from '@scullyio/scully';
 import '@notiz/scully-plugin-lazy-images';
 import '@notiz/scully-plugin-fouc';
 import '@notiz/scully-plugin-rss';
 import '@notiz/scully-plugin-medium-zoom';
 import './projects/banner-generator';
 import './projects/amp';
+import { getSitemapPlugin } from '@gammastream/scully-plugin-sitemap';
 
 const defaultPostRenderers = [
   'fouc',
@@ -12,7 +14,45 @@ const defaultPostRenderers = [
   'mediumZoom',
 ];
 
-exports.config = {
+const SitemapPlugin = getSitemapPlugin();
+setPluginConfig(SitemapPlugin, {
+  urlPrefix: 'https://notiz.dev',
+  sitemapFilename: 'sitemap.xml',
+  changeFreq: 'weekly',
+  priority: [
+    '1.0',
+    '0.9',
+    '0.8',
+    '0.7',
+    '0.6',
+    '0.5',
+    '0.4',
+    '0.3',
+    '0.2',
+    '0.1',
+    '0.0',
+  ],
+  ignoredRoutes: ['/404', '/confirm-subscription', '/unsubscribe'],
+  routes: {
+    '/blog/:slug': {
+      changeFreq: 'daily',
+      priority: '0.9',
+      sitemapFilename: 'sitemap-blog.xml',
+    },
+    '/links/:slug': {
+      changeFreq: 'daily',
+      priority: '0.9',
+      sitemapFilename: 'sitemap-links.xml',
+    },
+    '/tags/:slug': {
+      changeFreq: 'daily',
+      priority: '0.9',
+      sitemapFilename: 'sitemap-tags.xml',
+    },
+  },
+});
+
+export const config: ScullyConfig = {
   projectRoot: './src',
   projectName: 'notiz',
   defaultPostRenderers,


### PR DESCRIPTION
Scully sitemap plugin generates a `sitemap.xml` (`sitemap-blog.xml`, `sitemap-links.xml` and `sitemap-tags.xml`) which is useful for SEO (https://joshwcomeau.com/gatsby/seo-friendly-sitemap/)