### PR TITLE
Fix/tag-slug

### DIFF
--- a/src/app/components/article/article.component.html
+++ b/src/app/components/article/article.component.html
@@ -20,7 +20,7 @@
     *ngFor="let tag of route.tags | slice: 0:3"
     size="xl"
   >
-    <a [routerLink]="'/tags/' + tag | dash | lowercase">{{ tag }}</a>
+    <a [routerLink]="'/tags/' + (this.content.tagLink(tag) | async | dash | lowercase)">{{ tag }}</a>
   </niz-chip>
   <span class="absolute bottom-4 flex flow-row space-x-2 items-center h-6">
     <span class="font-bold text-color-light">Read More</span>

--- a/src/app/components/article/article.component.ts
+++ b/src/app/components/article/article.component.ts
@@ -1,5 +1,6 @@
 import { Component, OnInit, Input } from '@angular/core';
 import { ScullyRoute } from '@scullyio/ng-lib';
+import { ScullyContentService } from '@services/scully-content.service';
 import { ContentType } from 'src/app/types/types';
 
 
@@ -13,7 +14,7 @@ export class ArticleComponent implements OnInit {
   type: ContentType;
 
 
-
+  constructor(public content: ScullyContentService){}
   ngOnInit(): void {
     const type = this.route.route.split('/')[1];
     switch (type) {

--- a/src/app/components/featured/featured.component.html
+++ b/src/app/components/featured/featured.component.html
@@ -33,7 +33,7 @@
     >
       <a
         class="rounded-md focus-ring"
-        [routerLink]="'/tags/' + (tag | dash | lowercase)"
+        [routerLink]="'/tags/' + (this.content.tagLink(tag) | async | dash | lowercase)"
       >
         {{ tag }}
       </a>

--- a/src/app/components/featured/featured.component.ts
+++ b/src/app/components/featured/featured.component.ts
@@ -3,6 +3,7 @@ import { HttpClient } from '@angular/common/http';
 import { ScullyRoute } from '@scullyio/ng-lib';
 import { ContentType } from 'src/app/types/types';
 import { Observable } from 'rxjs';
+import { ScullyContentService } from '@services/scully-content.service';
 
 @Component({
   selector: 'app-featured',
@@ -13,7 +14,7 @@ export class FeaturedComponent implements OnInit {
   type: ContentType;
   @Input() route: ScullyRoute;
   sneakpeak$: Observable<string>;
-
+  constructor(public content: ScullyContentService){}
   ngOnInit(): void {
     const type = this.route.route.split('/')[1];
     switch (type) {

--- a/src/app/pages/blog-post/blog-post.component.html
+++ b/src/app/pages/blog-post/blog-post.component.html
@@ -55,7 +55,7 @@
               *ngFor="let tag of route.tags | slice: 0:3"
               size="xl"
             >
-              <a [routerLink]="'/tags/' + (tag | dash | lowercase)">
+              <a [routerLink]="'/tags/' + (this.content.tagLink(tag) | async | dash | lowercase)">
                 {{ tag }}
               </a>
             </niz-chip>

--- a/src/app/pages/blog-post/blog-post.component.ts
+++ b/src/app/pages/blog-post/blog-post.component.ts
@@ -30,7 +30,7 @@ export class BlogPostComponent implements OnInit, AfterViewChecked, OnDestroy {
 
   constructor(
     private highlightService: HighlightService,
-    private content: ScullyContentService,
+    public content: ScullyContentService,
     private router: Router
   ) {}
 

--- a/src/app/services/scully-content.service.ts
+++ b/src/app/services/scully-content.service.ts
@@ -82,6 +82,17 @@ export class ScullyContentService {
   tags(): Observable<ScullyRoute[]> {
     return filterRoute(this.scully.available$, '/tags/');
   }
+  
+  tagLink(tagTitle:string): Observable<string>{
+    return this.tags().pipe(
+      map(tag=>tag.filter(
+        (tag:ScullyRoute) => {
+          return tag.title.includes(tagTitle);
+        }
+      )),
+      map(tag=>tag[0].slug)
+    );
+  }
 
   authorTags(author: Observable<ScullyRoute>): Observable<ScullyRoute[]> {
     const authorPosts$ = this.authorPosts(author);


### PR DESCRIPTION
The tag link does not match the slug. I added the tagLink method to` scully-content.service` to match the `tag title` with the `tag slug`. And modify all the places where `tag.slug` does not match the link.
